### PR TITLE
負荷対策の変更をしました

### DIFF
--- a/lib/fluent/plugin/solr_config_common.rb
+++ b/lib/fluent/plugin/solr_config_common.rb
@@ -9,6 +9,8 @@ module SolrConfigCommon
   config_param :port,       :integer, default: 8983
   config_param :time_field, :string,  default: 'timestamp'
   config_param :commit,     :bool,    default: false
+  config_param :read_timeout, :integer, default: 600
+  config_param :send_rate,  :integer, default: 20
 
   include Fluent::SetTagKeyMixin
   config_set_default :include_tag_key, false

--- a/lib/fluent/plugin/solr_util.rb
+++ b/lib/fluent/plugin/solr_util.rb
@@ -13,9 +13,18 @@ module SolrUtil
       record.merge!(@time_field => time.strftime('%FT%TZ'))
       record.merge!(@tag_key    => tag) if @include_tag_key
       documents << record
+      if documents.count >= @send_rate
+        update_core_request(documents)
+        documents = []
+      end
     end
 
+    update_core_request(documents) if documents.count > 0
+  end
+
+  def update_core_request(documents)
     http = Net::HTTP.new(@host, @port.to_i)
+    http.read_timeout = @read_timeout
     url = '/solr/' + URI.escape(core) + '/update'
     url += '?commit=true' if @commit
     request = Net::HTTP::Post.new(url, 'content-type' => 'application/json; charset=utf-8')


### PR DESCRIPTION
こんにちは。
本プラグインで処理をしていたところ、大量の件数を処理するとSolr側が重くなり、タイムアウトしてしまう現象に直面しました。
そのため、以下の修正を加えました。

負荷が掛った際のタイムアウト回避のためタイムアウト(デフォルト:600秒)を設定できるようにしました。
また、Solrは一気にリクエスト掛けると重くなってしまうことがあるため、一定件数ずつ処理(デフォルト:20件)するようにしました。

よろしければ、取り込んで頂けるとありがたいです。
