### PR TITLE
Add missing development dependencies

### DIFF
--- a/fluent-plugin-out-solr.gemspec
+++ b/fluent-plugin-out-solr.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'webmock'
+  s.add_development_dependency 'test-unit', '~> 3.2'
+  s.add_development_dependency 'minitest', '~> 5.0'
 end


### PR DESCRIPTION
We should add `test-unit` and `minitest` into development dependencies.